### PR TITLE
Clean up TI code, removing human prompts

### DIFF
--- a/TMS570LS12x/ls12_uart_boot/bl_config.h
+++ b/TMS570LS12x/ls12_uart_boot/bl_config.h
@@ -72,8 +72,6 @@
 // Requires: UART_FIXED_BAUDRATE, BUFFER_SIZE
 //*****************************************************************************
 #define UART_ENABLE_UPDATE
-//#define SPI_ENABLE_UPDATE
-//#define CAN_ENABLE_UPDATE
 
 //*****************************************************************************
 // The starting address of the application.  This must be a multiple of 32K(sector size)
@@ -83,7 +81,6 @@
 // The flash image of the boot loader must not be larger than this value.
 //*****************************************************************************
 #define APP_START_ADDRESS       0x00010100
-// #define APP_START_ADDRESS       0x00020000
 
 //*****************************************************************************
 // The address to store the update status of the application image
@@ -92,11 +89,8 @@
 //*****************************************************************************
 #define APP_STATUS_ADDRESS       0x00010000
 
-/* UART is used in all the boot modes*/
-//#if defined (UART_ENABLE_UPDATE)
 #define UART_BAUDRATE     115200
 #define UART              sciREG1   /* Use UART port 1 for UART boot */
-//#endif
 
 #define BUFFER_SIZE             64       /*words in the data buffer used for receiving packets*/
 
@@ -130,6 +124,5 @@
 
 #endif
 
-// #define   DEBUG_MSG_L3
-#define DEBUG_MSG
+// #define DEBUG_MSG
 #endif // __BL_CONFIG_H__

--- a/inc/sci_common.h
+++ b/inc/sci_common.h
@@ -37,6 +37,8 @@ typedef  void (*pFunction)(void);
 #define CONVERTHEX_alpha(c)  (IS_AF(c) ? (c - 'A'+10) : (c - 'a'+10))
 #define CONVERTHEX(c)   (IS_09(c) ? (c - '0') : CONVERTHEX_alpha(c))
 
+#define CRLF "\r\n"
+
 /* Exported functions ------------------------------------------------------- */
 void Int2Str(char* str,int intnum);
 uint32_t Str2Int(unsigned char *inputstr,int *intnum);

--- a/src/bl_main.c
+++ b/src/bl_main.c
@@ -3,7 +3,7 @@
  * bl_main.c      : The main file for the boot loader.
  * Author         : QJ Wang. qjwang@ti.com
  * Date           : 2-18-2016
- * Heimir Thor Sverrisson, W1ANT updates 2022-08-26
+ * 2022-08-26 Heimir Thor Sverrisson, w1ant, heimir.sverrisson@gmail.com
  *
  * Copyright (c) 2006-2011 Texas Instruments Incorporated.  All rights reserved.
  * Software License Agreement
@@ -110,8 +110,10 @@ void main(void) {
 	/* Initialize SCI Routines to receive Command and transmit data */
 	sciInit();
 
+#ifdef DEBUG_MSG
 	UART_putString(UART, "\r\nHercules MCU UART BootLoader\r\n");
 	UART_putString(UART, "TI Safety MCU Application Team, qjwang@ti.com\r\n");
+#endif
 
 	// Bring GIO out of reset before the call to CheckForceUpdate() below
 	CheckGPIOForceUpdate();

--- a/src/sw_hw_ver.c
+++ b/src/sw_hw_ver.c
@@ -42,7 +42,8 @@
  *   @brief Get the Software Version of the Demo
  */
 void get_software_Version(void) {
-	UART_putString(UART, "\n\r The BootLoader Version: V1.0 \n\n\r");
+	UART_putString(UART, CRLF);
+	UART_putString(UART, "Flash Loader TI: 1.0.0");
 	return;
 }
 
@@ -59,17 +60,15 @@ void get_hardware_Info(void) {
 	LOT_NUM = ((DIE_ID1 & 0xFFC00000) >> 22) | ((DIE_ID2 & 0x00003FFF) << 10);
 	WAFER_LOC_NUM = (DIE_ID1 & 0x003FFFFF);
 
-	UART_putString(UART, "\n\r Device Information: \r\n ");
-
-	UART_putString(UART, "DEV:  ");
+	UART_putString(UART, CRLF);
+	UART_putString(UART, "DEV:           ");
 	UART_send32BitData(UART, systemREG1->DEV);
-	UART_putString(UART, "  \r\n ");
-	UART_putString(UART, "LOT NUM:  ");
+	UART_putString(UART, CRLF);
+	UART_putString(UART, "LOT NUM:       ");
 	UART_send32BitData(UART, LOT_NUM);
-	UART_putString(UART, " \r\n ");
-	UART_putString(UART, "WAFER LOC NUM:  ");
+	UART_putString(UART, CRLF);
+	UART_putString(UART, "WAFER LOC NUM: ");
 	UART_send32BitData(UART, (WAFER_LOC_NUM));
-	UART_putString(UART, " \n\n\r\n ");
 
 	return;
 }


### PR DESCRIPTION
Prompts over serial port now ready for host loader program.

Unless `DEBUG_MSG` is defined in `bl_config.h` only a simple `$ ` prompt is sent over the serial line.
If a human in connecting they can type `?` to get the available numerical values accepted by the code.

This PR contains the commits from from the previous one, as they have not been merged yet.